### PR TITLE
Create the tmp directory if it does not exist.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,7 @@ SimpleCov.start
 
 require 'minitest/autorun'
 require_relative '../lib/rhex'
+
+# Ensure the image output directory exists
+IMAGE_OUTPUT_DIRECTORY = 'tmp'
+Dir.mkdir(IMAGE_OUTPUT_DIRECTORY) unless Dir.exist?(IMAGE_OUTPUT_DIRECTORY)


### PR DESCRIPTION
On a fresh git checkout the 'tmp' directory used for storing test output
images does not exist. This adds a line to the test_helper to create the
directory if necessary.